### PR TITLE
Rescue from all exceptions when counting cores in the CPUCounter

### DIFF
--- a/lib/celluloid/internals/cpu_counter.rb
+++ b/lib/celluloid/internals/cpu_counter.rb
@@ -15,7 +15,7 @@ module Celluloid
         def from_env
           result = ENV["NUMBER_OF_PROCESSORS"]
           result if result && !result.empty?
-        rescue
+        rescue Exception => e
         end
 
         def from_sysdev
@@ -24,30 +24,30 @@ module Celluloid
           begin
             result = Dir["/sys/devices/system/cpu/cpu*"].count { |n| n =~ /cpu\d+/ }
             result unless result.zero?
-          rescue
+          rescue Exception => e
           end
-        rescue
+        rescue Exception => e
         end
 
         def from_java
           Java::Java.lang.Runtime.getRuntime.availableProcessors if defined? Java::Java
-        rescue
+        rescue Exception => e
         end
 
         def from_proc
           File.read('/proc/cpuinfo').scan(/^processor\s*:/).size if File.exist?('/proc/cpuinfo')
-        rescue
+        rescue Exception => e
         end
 
         def from_win32ole
           require 'win32ole'
           WIN32OLE.connect("winmgmts://").ExecQuery("select * from Win32_ComputerSystem").NumberOfProcessors
-        rescue
+        rescue Exception => e
         end
 
         def from_sysctl
           Integer `sysctl -n hw.ncpu 2>/dev/null`
-        rescue
+        rescue Exception => e
         end
 
         def from_result(result)
@@ -55,7 +55,7 @@ module Celluloid
             i = Integer(result.to_s[/\d+/], 10)
             return i if i > 0
           end
-        rescue
+        rescue Exception => e
         end
       end
     end


### PR DESCRIPTION
I noticed a bug on my machine with calculating the number of `cpu_cores`. On OSX El Capitan, with ruby version `ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-darwin14]`, it would blow up when trying to calculate the cores in the `from_win32ole` method. It was crashing with a `#<LoadError: cannot load such file -- win32ole>` error. I guess a regular `rescue` call doesn't capture LoadErrors, so I just made them catch all exceptions.

Not sure if this is the right fix or not! But I just hacked these changes into my local copy of celluloid-essentials and everything's working fine again.