### PR TITLE
New method publish_in_batches to limit parallelism

### DIFF
--- a/spec/celluloid/notifications_spec.rb
+++ b/spec/celluloid/notifications_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Celluloid::Notifications, actor_system: :global do
     def die(topic = "death")
       publish(topic, "Mr. President")
     end
+
+    def die_in_batches(topic = "death")
+      publish_in_batches(topic, 1, "Mr. President")
+    end
   end
 
   it "notifies relevant subscribers" do
@@ -35,6 +39,21 @@ RSpec.describe Celluloid::Notifications, actor_system: :global do
     expect(marilyn.mourning).to eq("Mr. President")
     expect(jackie.mourning).not_to eq("Mr. President")
   end
+
+  it "notifies relevant subscribers in batches" do
+    marilyn = Admirer.new
+    jackie = Admirer.new
+
+    marilyn.subscribe("death", :someone_died)
+    jackie.subscribe("alive", :someone_died)
+
+    president = President.new
+
+    president.die_in_batches
+    expect(marilyn.mourning).to eq("Mr. President")
+    expect(jackie.mourning).not_to eq("Mr. President")
+  end
+
 
   it "allows multiple subscriptions from the same actor" do
     marilyn = Admirer.new
@@ -58,6 +77,20 @@ RSpec.describe Celluloid::Notifications, actor_system: :global do
     president = President.new
 
     president.die
+    expect(marilyn.mourning).to eq("Mr. President")
+    expect(jackie.mourning).to eq("Mr. President")
+  end
+
+  it "notifies subscribers in batches" do
+    marilyn = Admirer.new
+    jackie = Admirer.new
+
+    marilyn.subscribe("death", :someone_died)
+    jackie.subscribe("death", :someone_died)
+
+    president = President.new
+
+    president.die_in_batches
     expect(marilyn.mourning).to eq("Mr. President")
     expect(jackie.mourning).to eq("Mr. President")
   end


### PR DESCRIPTION
Hi,

Using the `publish` method will iterate the subscribers and execute the passed method using `async`, which creates a fiber (or thread in jruby) .

```ruby
      def publish(pattern, *args)
        listeners_for(pattern).each { |s| s.publish(pattern, *args) }
      end
```

If you have too many subscribers, it may be a good idea in some cases to limit fiber or thread creation to save resources. To achieve that, I have added a `publish_in_batches` method.

```ruby
      def publish_in_batches(pattern, slice, *args)
        listeners_for(pattern).each_slice(slice) do |listeners|
          futures = listeners.map { |s| s.publish_in_batch(pattern, *args) }
          futures.map(&:value)
        end
      rescue DeadActorError
        # TODO: needs a tests
        # Bad shutdown logic. Oh well....
      end
```

Maybe it's not the best example, but think of a ruby script being executed on a system with a 10k file descriptor limit. If we call publish for 11k subscribers, and each call creates a network connection, we'll have a problem. 

Using the new `publish_in_batches` we could publish in 1k batches and never reach the limit as each batch needs to finish before the next one starts (I used futures for that).
